### PR TITLE
fix: Implement immediate balance refresh after transactions

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -306,6 +306,9 @@ class UUSDApp {
                 } else {
                     this.redeemComponent.handleTransactionSuccess(operation);
                 }
+                
+                // Trigger balance refresh after any successful transaction
+                void this.inventoryBarComponent.refreshBalances();
             },
             onTransactionError: (operation: string, error: Error) => {
                 if (operation === TransactionOperation.MINT) {

--- a/src/components/mint-component.ts
+++ b/src/components/mint-component.ts
@@ -256,6 +256,9 @@ export class MintComponent {
             this.services.notificationManager.showSuccess('mint', `Successfully minted ${amountInput.value} UUSD!`);
             amountInput.value = '';
             this.updateOutput();
+            
+            // Immediately refresh balances after successful mint
+            void this.services.inventoryBar.refreshBalances();
         }
     }
 

--- a/src/components/redeem-component.ts
+++ b/src/components/redeem-component.ts
@@ -230,9 +230,15 @@ export class RedeemComponent {
             this.services.notificationManager.showSuccess('redeem', `Successfully redeemed ${amountInput.value} UUSD! Collect your redemption to receive tokens.`);
             amountInput.value = '';
             this.updateOutput();
+            
+            // Immediately refresh balances after successful redeem
+            void this.services.inventoryBar.refreshBalances();
         } else if (operation === TransactionOperation.COLLECT_REDEMPTION) {
             this.services.notificationManager.showSuccess('redeem', 'Successfully collected redemption!');
             this.updateOutput();
+            
+            // Immediately refresh balances after collecting redemption
+            void this.services.inventoryBar.refreshBalances();
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds immediate balance refresh after all successful transactions
- Fixes issue where balances showed stale data after minting/redeeming UUSD

## Changes
- Added `refreshBalances()` call to mint component's `handleTransactionSuccess` method
- Added `refreshBalances()` call to redeem component's `handleTransactionSuccess` method (for both redeem and collect operations)
- Added global balance refresh in app.ts transaction success handler as a fallback

## Test Plan
1. Connect wallet with some LUSD balance
2. Mint UUSD and verify balances update immediately after transaction confirms
3. Redeem UUSD and verify balances update immediately after transaction confirms
4. Collect redemption and verify balances update immediately

Closes #34