### PR TITLE
feat: CoWSwap Improvements - Issue #47

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -45,7 +45,10 @@
         <div id="exchangeForm" class="exchange-form" style="display: none;">
             <form onsubmit="window.app.handleExchange(event)">
                 <div id="input" class="form-group">
-                    <input type="number" id="exchangeAmount" step="any" placeholder="Enter amount" required>
+                    <div class="input-with-max">
+                        <input type="number" id="exchangeAmount" step="any" placeholder="Enter amount" required>
+                        <button type="button" id="maxButton" class="max-button" title="Set maximum amount">Max</button>
+                    </div>
                 </div>
 
                 <!-- Optional: UBQ Discount (only shown when protocol allows) -->

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -828,3 +828,34 @@ hr{border: 0.5px solid #ffffff40;margin-bottom: 10px;margin-left: 8px;margin: 20
 button#connectWallet {
     margin: 20px auto;
 }
+
+.input-with-max {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.input-with-max input {
+    flex: 1;
+}
+
+.max-button {
+    padding: 6px 12px;
+    background: #2a2a3e;
+    color: #fff;
+    border: 1px solid #444;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 600;
+    white-space: nowrap;
+    transition: background 0.2s;
+}
+
+.max-button:hover {
+    background: #3a3a5e;
+}
+
+.max-button:active {
+    background: #4a4a6e;
+}

--- a/src/components/simplified-exchange-component.ts
+++ b/src/components/simplified-exchange-component.ts
@@ -163,11 +163,19 @@ export class SimplifiedExchangeComponent {
     const yourTokenGroup = document.getElementById("yourTokenGroup") as HTMLOptGroupElement;
     const otherTokenGroup = document.getElementById("otherTokenGroup") as HTMLOptGroupElement;
 
+    // Minimum USD value to display a token in the inventory list
+    const MIN_USD_VALUE = 1.0;
+
     if (refreshData?.tokenBalances) {
+      // Filter out dust tokens (value < $1.00)
+      const significantBalances = refreshData.tokenBalances.filter(
+        (balance) => !balance.usdValue || balance.usdValue >= MIN_USD_VALUE
+      );
+
       yourTokenGroup.style.display = "";
-      otherTokenGroup.style.display = "";
+
       if (
-        refreshData.tokenBalances.some((balance) => areAddressesEqual(balance.address, INVENTORY_TOKENS.LUSD.address)) &&
+        significantBalances.some((balance) => areAddressesEqual(balance.address, INVENTORY_TOKENS.LUSD.address)) &&
         !yourTokenGroup.querySelector(`option[value="${INVENTORY_TOKENS.LUSD.address}"i]`)
       ) {
         // Ensure LUSD is always in the first position
@@ -178,7 +186,7 @@ export class SimplifiedExchangeComponent {
         option.text = INVENTORY_TOKENS.LUSD.symbol.substring(0, 10);
         yourTokenGroup.insertBefore(option, yourTokenGroup.firstChild);
       }
-      refreshData.tokenBalances.forEach((balance) => {
+      significantBalances.forEach((balance) => {
         if (yourTokenGroup.querySelector(`option[value="${balance.address}"i]`)) {
           return; // Token already exists
         }
@@ -193,10 +201,13 @@ export class SimplifiedExchangeComponent {
       });
       // Remove old user's tokens
       yourTokenGroup.querySelectorAll("option").forEach((opt) => {
-        if (!refreshData.tokenBalances?.some((balance) => areAddressesEqual(balance.address, opt.value as Address))) {
+        if (!significantBalances?.some((balance) => areAddressesEqual(balance.address, opt.value as Address))) {
           opt.remove();
         }
       });
+
+      // Hide preloaded list when user already has tokens loaded
+      otherTokenGroup.style.display = significantBalances.length > 0 ? "none" : "";
     } else {
       yourTokenGroup.style.display = "none";
       yourTokenGroup.querySelectorAll("option").forEach((opt) => opt.remove());
@@ -353,6 +364,11 @@ export class SimplifiedExchangeComponent {
         amountInput.addEventListener("input", () => this._handleAmountChange());
       }
 
+      const maxButton = document.getElementById("maxButton") as HTMLButtonElement;
+      if (maxButton) {
+        maxButton.addEventListener("click", () => this._handleMaxButton());
+      }
+
       if (depositButton) {
         depositButton.addEventListener("click", () => this._switchDirection("deposit"));
       }
@@ -427,6 +443,29 @@ export class SimplifiedExchangeComponent {
     this._debounceTimer = setTimeout(() => {
       void this._calculateRoute();
     }, 1000);
+  }
+
+  /**
+   * Handle Max button click - set input to maximum available balance
+   */
+  private _handleMaxButton() {
+    if (!this._services.walletService.isConnected()) return;
+
+    try {
+      const selectedToken = this._state.direction === "deposit" ? this._getSelectedToken() : INVENTORY_TOKENS.UUSD;
+      const tokenSymbol = selectedToken.symbol;
+      if (hasAvailableBalance(this._services.inventoryBar, tokenSymbol)) {
+        const maxBalance = getMaxTokenBalance(this._services.inventoryBar, tokenSymbol);
+        const amountInput = document.getElementById("exchangeAmount") as HTMLInputElement;
+        if (amountInput) {
+          amountInput.value = maxBalance;
+          this._state.amount = maxBalance;
+          void this._calculateRoute();
+        }
+      }
+    } catch (error) {
+      console.error("Error setting max balance:", error);
+    }
   }
 
   private _getSelectedToken() {

--- a/src/components/simplified-exchange-component.ts
+++ b/src/components/simplified-exchange-component.ts
@@ -169,7 +169,7 @@ export class SimplifiedExchangeComponent {
     if (refreshData?.tokenBalances) {
       // Filter out dust tokens (value < $1.00)
       const significantBalances = refreshData.tokenBalances.filter(
-        (balance) => !balance.usdValue || balance.usdValue >= MIN_USD_VALUE
+        (balance) => balance.usdValue == null || balance.usdValue >= MIN_USD_VALUE
       );
 
       yourTokenGroup.style.display = "";
@@ -454,14 +454,19 @@ export class SimplifiedExchangeComponent {
     try {
       const selectedToken = this._state.direction === "deposit" ? this._getSelectedToken() : INVENTORY_TOKENS.UUSD;
       const tokenSymbol = selectedToken.symbol;
+      const amountInput = document.getElementById("exchangeAmount") as HTMLInputElement;
       if (hasAvailableBalance(this._services.inventoryBar, tokenSymbol)) {
         const maxBalance = getMaxTokenBalance(this._services.inventoryBar, tokenSymbol);
-        const amountInput = document.getElementById("exchangeAmount") as HTMLInputElement;
         if (amountInput) {
           amountInput.value = maxBalance;
           this._state.amount = maxBalance;
           void this._calculateRoute();
         }
+      } else if (amountInput) {
+        // Clear stale input when Max resolves to no balance
+        amountInput.value = "";
+        this._state.amount = "";
+        void this._calculateRoute();
       }
     } catch (error) {
       console.error("Error setting max balance:", error);


### PR DESCRIPTION
Addresses: #47

## Changes

### 1. Filter inventory tokens < $1.00
Only display tokens with USD value ≥ $1.00 in the inventory selector. Dust tokens are hidden to reduce noise in the UI.

### 2. Hide preloaded token list when user has tokens
The static "Other Tokens" preloaded list is hidden when the user already has tokens loaded in their wallet, as it doesn't make sense to show a generic list alongside personalized inventory.

### 3. Add Max button
Added a "Max" button next to the amount input field that fills in the maximum available balance for the selected token with a single click.