### PR TITLE
Improve CowSwap inventory token selection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -45,7 +45,10 @@
         <div id="exchangeForm" class="exchange-form" style="display: none;">
             <form onsubmit="window.app.handleExchange(event)">
                 <div id="input" class="form-group">
-                    <input type="number" id="exchangeAmount" step="any" placeholder="Enter amount" required>
+                    <div class="amount-input-wrapper">
+                        <input type="number" id="exchangeAmount" step="any" placeholder="Enter amount" required>
+                        <button type="button" id="maxAmountButton" class="max-amount-button">Max</button>
+                    </div>
                 </div>
 
                 <!-- Optional: UBQ Discount (only shown when protocol allows) -->

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -35,6 +35,9 @@ button:disabled { cursor: not-allowed; }
 label {/* display: block; */margin: 8px;font-weight: 600;}
 input, select {padding: 10px;border: 1px solid #ddd;border-radius: 6px;font-size: 16px;background-color: transparent;border-color: transparent;box-shadow: 0 0 96px #ffffff40;color: #fff; }
 input:focus, select:focus { outline: none; }
+.amount-input-wrapper {display: flex;align-items: center;gap: 8px;}
+.amount-input-wrapper input {flex: 1;min-width: 0;}
+.max-amount-button {padding: 10px 14px;font-size: 14px;min-width: 64px;}
 .output-section { margin-top: 20px; padding: 20px; border-radius: 8px; }
 .output-row { display: flex; justify-content: space-between; margin-bottom: 10px; }
 .output-label { }

--- a/src/components/inventory-bar-component.ts
+++ b/src/components/inventory-bar-component.ts
@@ -6,7 +6,7 @@ import type { PriceService } from "../services/price-service.ts";
 import type { NotificationManager } from "./notification-manager.ts";
 import type { CentralizedRefreshService, RefreshData } from "../services/centralized-refresh-service.ts";
 import type { TokenBalance, InventoryBarState } from "../types/inventory.types.ts";
-import { formatTokenAmount, formatUsdValue, calculateTotalUsdValue, isBalanceZero } from "../utils/token-utils.ts";
+import { formatTokenAmount, formatUsdValue, calculateTotalUsdValue, isBalanceZero, hasVisibleTokenValue, sortBalancesByValue } from "../utils/token-utils.ts";
 import { batchFetchTokenBalances } from "../utils/batch-request-utils.ts";
 
 import icons from "./icons.ts";
@@ -130,7 +130,7 @@ export class InventoryBarComponent {
 
       // Update state with merged data
       this._state.balances = updatedBalances;
-      this._state.totalUsdValue = calculateTotalUsdValue(updatedBalances);
+      this._state.totalUsdValue = calculateTotalUsdValue(this._getVisibleBalances(updatedBalances));
       this._state.isLoading = false;
 
       console.log("📊 Final inventory state:", {
@@ -286,7 +286,7 @@ export class InventoryBarComponent {
       const balances = await Promise.all(balancePromises);
 
       this._state.balances = balances;
-      this._state.totalUsdValue = calculateTotalUsdValue(balances);
+      this._state.totalUsdValue = calculateTotalUsdValue(this._getVisibleBalances(balances));
       this._state.isLoading = false;
 
       this._renderBalances();
@@ -400,6 +400,10 @@ export class InventoryBarComponent {
   /**
    * Render token balances
    */
+  private _getVisibleBalances(balances: TokenBalance[] = this._state.balances): TokenBalance[] {
+    return sortBalancesByValue(balances.filter(hasVisibleTokenValue));
+  }
+
   private _renderBalances(): void {
     const tokensContainer = document.getElementById("inventory-tokens");
     const totalValueElement = document.getElementById("inventory-total");
@@ -418,16 +422,16 @@ export class InventoryBarComponent {
       return;
     }
 
-    // Filter out zero balances and render individual token balances
-    const nonZeroBalances = this._state.balances.filter((balance) => !isBalanceZero(balance.balance, balance.decimals));
+    // Hide low-value dust so the inventory view stays readable.
+    const visibleBalances = this._getVisibleBalances();
 
-    if (nonZeroBalances.length === 0) {
-      tokensContainer.innerHTML = '<div class="no-balances-message">No token balances available</div>';
+    if (visibleBalances.length === 0) {
+      tokensContainer.innerHTML = '<div class="no-balances-message">No token balances over $1.00</div>';
       totalValueElement.textContent = "$0.00";
       return;
     }
 
-    const tokenElements = nonZeroBalances
+    const tokenElements = visibleBalances
       .map((balance) => {
         const amount = formatTokenAmount(balance.balance, balance.decimals);
         const usdValue = balance.usdValue ? formatUsdValue(balance.usdValue) : "";
@@ -447,7 +451,7 @@ export class InventoryBarComponent {
       .join("");
 
     tokensContainer.innerHTML = tokenElements;
-    totalValueElement.textContent = formatUsdValue(this._state.totalUsdValue);
+    totalValueElement.textContent = formatUsdValue(calculateTotalUsdValue(visibleBalances));
   }
 
   /**

--- a/src/components/simplified-exchange-component.ts
+++ b/src/components/simplified-exchange-component.ts
@@ -14,10 +14,10 @@ import type { InventoryBarComponent } from "./inventory-bar-component.ts";
 import { getMaxTokenBalance, hasAvailableBalance } from "../utils/balance-utils.ts";
 import { DEFAULT_SLIPPAGE_PERCENT, DEFAULT_SLIPPAGE_BPS, BASIS_POINTS_DIVISOR } from "../constants/numeric-constants.ts";
 import type { CentralizedRefreshService, RefreshData } from "../services/centralized-refresh-service.ts";
-import { INVENTORY_TOKENS } from "../types/inventory.types.ts";
+import { INVENTORY_TOKENS, type TokenBalance } from "../types/inventory.types.ts";
 import { areAddressesEqual } from "../utils/format-utils.ts";
 import type { CowSwapService } from "../services/cowswap-service.ts";
-import tokenList from "../constants/token-list.json" with { type: "json" };
+import { hasVisibleTokenValue, sortBalancesByValue } from "../utils/token-utils.ts";
 
 interface SimplifiedExchangeServices {
   walletService: WalletService;
@@ -162,74 +162,53 @@ export class SimplifiedExchangeComponent {
     }
     const yourTokenGroup = document.getElementById("yourTokenGroup") as HTMLOptGroupElement;
     const otherTokenGroup = document.getElementById("otherTokenGroup") as HTMLOptGroupElement;
+    const previousSelection = selectEl.value;
 
-    if (refreshData?.tokenBalances) {
+    yourTokenGroup.replaceChildren();
+    otherTokenGroup.replaceChildren();
+
+    const walletTokens = sortBalancesByValue((refreshData?.tokenBalances ?? []).filter(hasVisibleTokenValue));
+
+    if (walletTokens.length > 0) {
       yourTokenGroup.style.display = "";
-      otherTokenGroup.style.display = "";
-      if (
-        refreshData.tokenBalances.some((balance) => areAddressesEqual(balance.address, INVENTORY_TOKENS.LUSD.address)) &&
-        !yourTokenGroup.querySelector(`option[value="${INVENTORY_TOKENS.LUSD.address}"i]`)
-      ) {
-        // Ensure LUSD is always in the first position
-        const option = document.createElement("option");
-        option.value = INVENTORY_TOKENS.LUSD.address;
-        option.setAttribute("data-decimals", INVENTORY_TOKENS.LUSD.decimals.toString());
-        option.setAttribute("data-symbol", INVENTORY_TOKENS.LUSD.symbol);
-        option.text = INVENTORY_TOKENS.LUSD.symbol.substring(0, 10);
-        yourTokenGroup.insertBefore(option, yourTokenGroup.firstChild);
-      }
-      refreshData.tokenBalances.forEach((balance) => {
-        if (yourTokenGroup.querySelector(`option[value="${balance.address}"i]`)) {
-          return; // Token already exists
-        }
-        otherTokenGroup.querySelector(`option[value="${balance.address}"i]`)?.remove(); // Remove from other tokens if present
-
-        const option = document.createElement("option");
-        option.value = balance.address;
-        option.setAttribute("data-decimals", balance.decimals.toString());
-        option.setAttribute("data-symbol", balance.symbol);
-        option.text = balance.symbol.substring(0, 10);
-        yourTokenGroup.appendChild(option);
-      });
-      // Remove old user's tokens
-      yourTokenGroup.querySelectorAll("option").forEach((opt) => {
-        if (!refreshData.tokenBalances?.some((balance) => areAddressesEqual(balance.address, opt.value as Address))) {
-          opt.remove();
-        }
-      });
+      walletTokens.forEach((balance) => this._appendTokenOption(yourTokenGroup, balance));
     } else {
       yourTokenGroup.style.display = "none";
-      yourTokenGroup.querySelectorAll("option").forEach((opt) => opt.remove());
     }
 
-    if (
-      !yourTokenGroup.querySelector(`option[value="${INVENTORY_TOKENS.LUSD.address}"i]`) &&
-      !otherTokenGroup.querySelector(`option[value="${INVENTORY_TOKENS.LUSD.address}"i]`)
-    ) {
-      // Ensure LUSD is always in the first position
-      const option = document.createElement("option");
-      option.value = INVENTORY_TOKENS.LUSD.address;
-      option.setAttribute("data-decimals", INVENTORY_TOKENS.LUSD.decimals.toString());
-      option.setAttribute("data-symbol", INVENTORY_TOKENS.LUSD.symbol);
-      option.text = INVENTORY_TOKENS.LUSD.symbol.substring(0, 10);
-      otherTokenGroup.insertBefore(option, otherTokenGroup.firstChild);
+    if (!this._hasTokenOption(selectEl, INVENTORY_TOKENS.LUSD.address)) {
+      this._appendTokenOption(otherTokenGroup, INVENTORY_TOKENS.LUSD);
     }
-    tokenList.forEach((token) => {
-      if ([...selectEl.options].some((opt) => areAddressesEqual(opt.value as Address, token.address as Address))) {
-        return; // Token already exists
-      }
-      const option = document.createElement("option");
-      option.value = token.address;
-      option.setAttribute("data-decimals", token.decimals.toString());
-      option.setAttribute("data-symbol", token.symbol);
-      option.text = token.symbol.substring(0, 10);
-      otherTokenGroup.appendChild(option);
-    });
-    otherTokenGroup.querySelectorAll("option").forEach((opt) => {
-      if (yourTokenGroup.querySelector(`option[value="${opt.value}"i]`)) {
-        opt.remove();
-      }
-    });
+
+    otherTokenGroup.style.display = otherTokenGroup.childElementCount > 0 ? "" : "none";
+    this._restoreTokenSelection(selectEl, previousSelection);
+  }
+
+  private _appendTokenOption(group: HTMLOptGroupElement, token: Pick<TokenBalance, "address" | "symbol" | "decimals">): void {
+    const option = document.createElement("option");
+    option.value = token.address;
+    option.setAttribute("data-decimals", token.decimals.toString());
+    option.setAttribute("data-symbol", token.symbol);
+    option.text = token.symbol.substring(0, 10);
+    group.appendChild(option);
+  }
+
+  private _hasTokenOption(selectEl: HTMLSelectElement, address: Address): boolean {
+    return [...selectEl.options].some((opt) => areAddressesEqual(opt.value as Address, address));
+  }
+
+  private _restoreTokenSelection(selectEl: HTMLSelectElement, previousSelection: string): void {
+    if (previousSelection && this._hasTokenOption(selectEl, previousSelection as Address)) {
+      selectEl.value = previousSelection;
+      return;
+    }
+
+    const lusdOption = [...selectEl.options].find((opt) => areAddressesEqual(opt.value as Address, INVENTORY_TOKENS.LUSD.address));
+    if (lusdOption) {
+      selectEl.value = lusdOption.value;
+    } else if (selectEl.options.length > 0) {
+      selectEl.selectedIndex = 0;
+    }
   }
 
   /**
@@ -353,6 +332,11 @@ export class SimplifiedExchangeComponent {
         amountInput.addEventListener("input", () => this._handleAmountChange());
       }
 
+      const maxAmountButton = document.getElementById("maxAmountButton") as HTMLButtonElement;
+      if (maxAmountButton) {
+        maxAmountButton.addEventListener("click", () => this._handleMaxButtonClick());
+      }
+
       if (depositButton) {
         depositButton.addEventListener("click", () => this._switchDirection("deposit"));
       }
@@ -427,6 +411,20 @@ export class SimplifiedExchangeComponent {
     this._debounceTimer = setTimeout(() => {
       void this._calculateRoute();
     }, 1000);
+  }
+
+  private _handleMaxButtonClick() {
+    if (!this._services.walletService.isConnected()) return;
+
+    const amountInput = document.getElementById("exchangeAmount") as HTMLInputElement;
+    if (!amountInput) return;
+
+    const selectedToken = this._state.direction === "deposit" ? this._getSelectedToken() : INVENTORY_TOKENS.UUSD;
+    const maxBalance = getMaxTokenBalance(this._services.inventoryBar, selectedToken.symbol);
+
+    amountInput.value = maxBalance;
+    this._state.amount = maxBalance;
+    void this._calculateRoute();
   }
 
   private _getSelectedToken() {

--- a/src/utils/balance-utils.ts
+++ b/src/utils/balance-utils.ts
@@ -25,7 +25,7 @@ export function getMaxTokenBalance(inventoryBar: InventoryBarComponent, tokenSym
   const formattedBalance = formatUnits(tokenBalance.balance, tokenBalance.decimals);
 
   // Remove trailing zeros and ensure clean formatting
-  const cleanBalance = formattedBalance.replace(/\.?0+$/, "");
+  const cleanBalance = formattedBalance.replace(/\.?0+$/, "") || "0";
 
   return cleanBalance;
 }

--- a/src/utils/token-utils.ts
+++ b/src/utils/token-utils.ts
@@ -1,6 +1,8 @@
 import { formatUnits, parseUnits, type Address as _Address } from "viem";
 import type { TokenBalance, TokenMetadata } from "../types/inventory.types.ts";
 
+export const MIN_VISIBLE_TOKEN_USD_VALUE = 1;
+
 /**
  * Format token amount for display with appropriate decimal places
  */
@@ -54,6 +56,13 @@ export function calculateTotalUsdValue(balances: TokenBalance[]): number {
  */
 export function isBalanceZero(balance: bigint, decimals: number): boolean {
   return balance < parseUnits("0.0001", decimals);
+}
+
+/**
+ * Check whether a token should be shown in inventory-facing UI.
+ */
+export function hasVisibleTokenValue(balance: TokenBalance): boolean {
+  return !isBalanceZero(balance.balance, balance.decimals) && (balance.usdValue ?? 0) > MIN_VISIBLE_TOKEN_USD_VALUE;
 }
 
 /**


### PR DESCRIPTION
Resolves #47

## Summary
- filter the inventory bar to only show token balances worth more than $1.00
- remove the large preloaded token list from the exchange selector so it focuses on wallet tokens plus the LUSD fallback
- add an explicit Max button beside the exchange amount input
- preserve token selection when balance refreshes re-render the selector

## Verification
- bun run typecheck
- bun run lint
- bun run format:check
- bunx esbuild src/app.ts --bundle --outfile=public/app.js --minify --format=esm --platform=browser --sourcemap
- checked the local page at desktop and mobile widths