### PR TITLE
Fix CoWSwap integration improvements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -45,7 +45,10 @@
         <div id="exchangeForm" class="exchange-form" style="display: none;">
             <form onsubmit="window.app.handleExchange(event)">
                 <div id="input" class="form-group">
-                    <input type="number" id="exchangeAmount" step="any" placeholder="Enter amount" required>
+                    <div class="amount-input-row">
+                        <input type="number" id="exchangeAmount" step="any" placeholder="Enter amount" required>
+                        <button type="button" id="maxAmountButton" class="max-button" disabled>Max</button>
+                    </div>
                 </div>
 
                 <!-- Optional: UBQ Discount (only shown when protocol allows) -->

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -35,6 +35,25 @@ button:disabled { cursor: not-allowed; }
 label {/* display: block; */margin: 8px;font-weight: 600;}
 input, select {padding: 10px;border: 1px solid #ddd;border-radius: 6px;font-size: 16px;background-color: transparent;border-color: transparent;box-shadow: 0 0 96px #ffffff40;color: #fff; }
 input:focus, select:focus { outline: none; }
+.amount-input-row {
+    display: flex;
+    align-items: stretch;
+    gap: 8px;
+    width: 100%;
+}
+.amount-input-row input {
+    flex: 1;
+    min-width: 0;
+}
+.max-button {
+    flex: 0 0 auto;
+    padding: 10px 14px;
+    font-size: 14px;
+    box-shadow: 0 0 96px #ffffff40;
+}
+.max-button:disabled {
+    opacity: 0.45;
+}
 .output-section { margin-top: 20px; padding: 20px; border-radius: 8px; }
 .output-row { display: flex; justify-content: space-between; margin-bottom: 10px; }
 .output-label { }

--- a/src/components/inventory-bar-component.ts
+++ b/src/components/inventory-bar-component.ts
@@ -11,6 +11,8 @@ import { batchFetchTokenBalances } from "../utils/batch-request-utils.ts";
 
 import icons from "./icons.ts";
 
+const MIN_VISIBLE_USD_VALUE = 1;
+
 /**
  * Service dependencies for InventoryBarComponent
  */
@@ -418,16 +420,18 @@ export class InventoryBarComponent {
       return;
     }
 
-    // Filter out zero balances and render individual token balances
-    const nonZeroBalances = this._state.balances.filter((balance) => !isBalanceZero(balance.balance, balance.decimals));
+    // Filter out zero and low-value balances so wallet dust does not dominate the inventory.
+    const visibleBalances = this._state.balances.filter(
+      (balance) => !isBalanceZero(balance.balance, balance.decimals) && (balance.usdValue ?? 0) >= MIN_VISIBLE_USD_VALUE
+    );
 
-    if (nonZeroBalances.length === 0) {
-      tokensContainer.innerHTML = '<div class="no-balances-message">No token balances available</div>';
+    if (visibleBalances.length === 0) {
+      tokensContainer.innerHTML = '<div class="no-balances-message">No token balances above $1.00</div>';
       totalValueElement.textContent = "$0.00";
       return;
     }
 
-    const tokenElements = nonZeroBalances
+    const tokenElements = visibleBalances
       .map((balance) => {
         const amount = formatTokenAmount(balance.balance, balance.decimals);
         const usdValue = balance.usdValue ? formatUsdValue(balance.usdValue) : "";
@@ -447,7 +451,7 @@ export class InventoryBarComponent {
       .join("");
 
     tokensContainer.innerHTML = tokenElements;
-    totalValueElement.textContent = formatUsdValue(this._state.totalUsdValue);
+    totalValueElement.textContent = formatUsdValue(calculateTotalUsdValue(visibleBalances));
   }
 
   /**

--- a/src/components/simplified-exchange-component.ts
+++ b/src/components/simplified-exchange-component.ts
@@ -14,10 +14,12 @@ import type { InventoryBarComponent } from "./inventory-bar-component.ts";
 import { getMaxTokenBalance, hasAvailableBalance } from "../utils/balance-utils.ts";
 import { DEFAULT_SLIPPAGE_PERCENT, DEFAULT_SLIPPAGE_BPS, BASIS_POINTS_DIVISOR } from "../constants/numeric-constants.ts";
 import type { CentralizedRefreshService, RefreshData } from "../services/centralized-refresh-service.ts";
-import { INVENTORY_TOKENS } from "../types/inventory.types.ts";
+import { INVENTORY_TOKENS, type TokenBalance } from "../types/inventory.types.ts";
 import { areAddressesEqual } from "../utils/format-utils.ts";
 import type { CowSwapService } from "../services/cowswap-service.ts";
 import tokenList from "../constants/token-list.json" with { type: "json" };
+
+const MIN_VISIBLE_TOKEN_USD_VALUE = 1;
 
 interface SimplifiedExchangeServices {
   walletService: WalletService;
@@ -162,74 +164,60 @@ export class SimplifiedExchangeComponent {
     }
     const yourTokenGroup = document.getElementById("yourTokenGroup") as HTMLOptGroupElement;
     const otherTokenGroup = document.getElementById("otherTokenGroup") as HTMLOptGroupElement;
+    const previousValue = selectEl.value;
 
-    if (refreshData?.tokenBalances) {
-      yourTokenGroup.style.display = "";
-      otherTokenGroup.style.display = "";
-      if (
-        refreshData.tokenBalances.some((balance) => areAddressesEqual(balance.address, INVENTORY_TOKENS.LUSD.address)) &&
-        !yourTokenGroup.querySelector(`option[value="${INVENTORY_TOKENS.LUSD.address}"i]`)
-      ) {
-        // Ensure LUSD is always in the first position
-        const option = document.createElement("option");
-        option.value = INVENTORY_TOKENS.LUSD.address;
-        option.setAttribute("data-decimals", INVENTORY_TOKENS.LUSD.decimals.toString());
-        option.setAttribute("data-symbol", INVENTORY_TOKENS.LUSD.symbol);
-        option.text = INVENTORY_TOKENS.LUSD.symbol.substring(0, 10);
-        yourTokenGroup.insertBefore(option, yourTokenGroup.firstChild);
+    yourTokenGroup.replaceChildren();
+    otherTokenGroup.replaceChildren();
+
+    function appendOption(group: HTMLOptGroupElement, token: { address: Address; decimals: number; symbol: string }) {
+      if ([...selectEl.options].some((opt) => areAddressesEqual(opt.value as Address, token.address))) {
+        return;
       }
-      refreshData.tokenBalances.forEach((balance) => {
-        if (yourTokenGroup.querySelector(`option[value="${balance.address}"i]`)) {
-          return; // Token already exists
-        }
-        otherTokenGroup.querySelector(`option[value="${balance.address}"i]`)?.remove(); // Remove from other tokens if present
 
-        const option = document.createElement("option");
-        option.value = balance.address;
-        option.setAttribute("data-decimals", balance.decimals.toString());
-        option.setAttribute("data-symbol", balance.symbol);
-        option.text = balance.symbol.substring(0, 10);
-        yourTokenGroup.appendChild(option);
-      });
-      // Remove old user's tokens
-      yourTokenGroup.querySelectorAll("option").forEach((opt) => {
-        if (!refreshData.tokenBalances?.some((balance) => areAddressesEqual(balance.address, opt.value as Address))) {
-          opt.remove();
-        }
-      });
-    } else {
-      yourTokenGroup.style.display = "none";
-      yourTokenGroup.querySelectorAll("option").forEach((opt) => opt.remove());
-    }
-
-    if (
-      !yourTokenGroup.querySelector(`option[value="${INVENTORY_TOKENS.LUSD.address}"i]`) &&
-      !otherTokenGroup.querySelector(`option[value="${INVENTORY_TOKENS.LUSD.address}"i]`)
-    ) {
-      // Ensure LUSD is always in the first position
-      const option = document.createElement("option");
-      option.value = INVENTORY_TOKENS.LUSD.address;
-      option.setAttribute("data-decimals", INVENTORY_TOKENS.LUSD.decimals.toString());
-      option.setAttribute("data-symbol", INVENTORY_TOKENS.LUSD.symbol);
-      option.text = INVENTORY_TOKENS.LUSD.symbol.substring(0, 10);
-      otherTokenGroup.insertBefore(option, otherTokenGroup.firstChild);
-    }
-    tokenList.forEach((token) => {
-      if ([...selectEl.options].some((opt) => areAddressesEqual(opt.value as Address, token.address as Address))) {
-        return; // Token already exists
-      }
       const option = document.createElement("option");
       option.value = token.address;
       option.setAttribute("data-decimals", token.decimals.toString());
       option.setAttribute("data-symbol", token.symbol);
       option.text = token.symbol.substring(0, 10);
-      otherTokenGroup.appendChild(option);
-    });
-    otherTokenGroup.querySelectorAll("option").forEach((opt) => {
-      if (yourTokenGroup.querySelector(`option[value="${opt.value}"i]`)) {
-        opt.remove();
+      group.appendChild(option);
+    }
+
+    function isVisibleWalletToken(balance: TokenBalance) {
+      return (
+        balance.balance > 0n && (balance.usdValue ?? 0) >= MIN_VISIBLE_TOKEN_USD_VALUE && !areAddressesEqual(balance.address, INVENTORY_TOKENS.UUSD.address)
+      );
+    }
+    const walletBalances = refreshData?.tokenBalances ?? null;
+
+    if (walletBalances) {
+      const visibleWalletBalances = walletBalances.filter(isVisibleWalletToken);
+
+      yourTokenGroup.style.display = visibleWalletBalances.length > 0 ? "" : "none";
+      visibleWalletBalances.forEach((balance) => appendOption(yourTokenGroup, balance));
+
+      // Once wallet inventory is available, do not show the large preloaded token list.
+      // Keep LUSD as a protocol-native fallback if it is not already in the wallet group.
+      if (!yourTokenGroup.querySelector(`option[value="${INVENTORY_TOKENS.LUSD.address}"i]`)) {
+        appendOption(otherTokenGroup, INVENTORY_TOKENS.LUSD);
       }
-    });
+      otherTokenGroup.style.display = otherTokenGroup.children.length > 0 ? "" : "none";
+    } else {
+      yourTokenGroup.style.display = "none";
+      otherTokenGroup.style.display = "";
+
+      appendOption(otherTokenGroup, INVENTORY_TOKENS.LUSD);
+      tokenList.forEach((token) =>
+        appendOption(otherTokenGroup, {
+          address: token.address as Address,
+          decimals: token.decimals,
+          symbol: token.symbol,
+        })
+      );
+    }
+
+    if (previousValue && [...selectEl.options].some((opt) => areAddressesEqual(opt.value as Address, previousValue as Address))) {
+      selectEl.value = previousValue;
+    }
   }
 
   /**
@@ -337,6 +325,7 @@ export class SimplifiedExchangeComponent {
     // eslint-disable-next-line func-style
     const setupListeners = () => {
       const amountInput = document.getElementById("exchangeAmount") as HTMLInputElement;
+      const maxButton = document.getElementById("maxAmountButton") as HTMLButtonElement;
       const depositButton = document.getElementById("depositButton") as HTMLButtonElement;
       const withdrawButton = document.getElementById("withdrawButton") as HTMLButtonElement;
       const ubqDiscountCheckbox = document.getElementById("useUbqDiscount") as HTMLInputElement;
@@ -351,6 +340,10 @@ export class SimplifiedExchangeComponent {
 
       if (amountInput) {
         amountInput.addEventListener("input", () => this._handleAmountChange());
+      }
+
+      if (maxButton) {
+        maxButton.addEventListener("click", () => this._handleMaxAmountClick());
       }
 
       if (depositButton) {
@@ -427,6 +420,39 @@ export class SimplifiedExchangeComponent {
     this._debounceTimer = setTimeout(() => {
       void this._calculateRoute();
     }, 1000);
+  }
+
+  private _getCurrentInputToken() {
+    return this._state.direction === "deposit" ? this._getSelectedToken() : INVENTORY_TOKENS.UUSD;
+  }
+
+  private _getMaxAmountForCurrentInput(): string {
+    const inputToken = this._getCurrentInputToken();
+    const tokenBalance = this._services.inventoryBar.getBalances().find((balance) => areAddressesEqual(balance.address, inputToken.address));
+
+    if (!tokenBalance || tokenBalance.balance <= 0n) {
+      return "0";
+    }
+
+    return formatUnits(tokenBalance.balance, tokenBalance.decimals).replace(/\.?0+$/, "") || "0";
+  }
+
+  private _handleMaxAmountClick() {
+    const maxAmount = this._getMaxAmountForCurrentInput();
+    if (maxAmount === "0") {
+      return;
+    }
+
+    const amountInput = document.getElementById("exchangeAmount") as HTMLInputElement;
+    if (!amountInput) {
+      return;
+    }
+
+    amountInput.value = maxAmount;
+    this._state.amount = maxAmount;
+    this._services.notificationManager.clearNotifications("exchange");
+    void this._calculateRoute();
+    this._updateMaxButtonState();
   }
 
   private _getSelectedToken() {
@@ -638,8 +664,32 @@ export class SimplifiedExchangeComponent {
 
     // Show/hide options based on protocol state and direction
     this._renderTokenOptions();
+    this._updateMaxButtonState();
     this._renderOptions();
     this._renderOutput();
+  }
+
+  private _updateMaxButtonState() {
+    const maxButton = document.getElementById("maxAmountButton") as HTMLButtonElement;
+    if (!maxButton) {
+      return;
+    }
+
+    if (!this._services.walletService.isConnected() || !this._services.inventoryBar.isInitialLoadComplete()) {
+      maxButton.disabled = true;
+      maxButton.title = "Connect wallet to use max";
+      return;
+    }
+
+    try {
+      const maxAmount = this._getMaxAmountForCurrentInput();
+      maxButton.disabled = maxAmount === "0";
+      maxButton.title = maxButton.disabled ? "No balance available for selected token" : `Use ${maxAmount}`;
+    } catch (error) {
+      console.error("Error updating max button:", error);
+      maxButton.disabled = true;
+      maxButton.title = "Balance unavailable";
+    }
   }
 
   /**

--- a/src/services/transaction-state-service.ts
+++ b/src/services/transaction-state-service.ts
@@ -319,6 +319,7 @@ export class TransactionStateService {
     document.getElementById("exchangeButton")?.setAttribute("disabled", "true");
     document.getElementById("tokenSelect")?.setAttribute("disabled", "true");
     document.getElementById("exchangeAmount")?.setAttribute("disabled", "true");
+    document.getElementById("maxAmountButton")?.setAttribute("disabled", "true");
   }
 
   enableAllInteractiveElements(): void {
@@ -328,5 +329,6 @@ export class TransactionStateService {
     document.getElementById("exchangeButton")?.removeAttribute("disabled");
     document.getElementById("tokenSelect")?.removeAttribute("disabled");
     document.getElementById("exchangeAmount")?.removeAttribute("disabled");
+    document.getElementById("maxAmountButton")?.removeAttribute("disabled");
   }
 }


### PR DESCRIPTION
## Summary
- hide wallet inventory entries below $1.00 so dust balances do not dominate the inventory bar
- use wallet-loaded token balances for the token selector once inventory data is available, while keeping a fallback token list before balances load
- add a Max button that fills the amount input from the currently selected input token balance

## Validation
- npm run typecheck
- npm run format:check
- npm run lint
- npx esbuild src/app.ts --bundle --format=esm --outfile=/tmp/uusd-app.js

Fixes #47
