### PR TITLE
Fix CoWSwap inventory and max amount UX

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
             <form onsubmit="window.app.handleExchange(event)">
                 <div id="input" class="form-group">
                     <div class="amount-input-row">
-                        <input type="number" id="exchangeAmount" step="any" placeholder="Enter amount" required>
+                        <input type="number" id="exchangeAmount" step="any" placeholder="Enter amount" aria-label="Exchange amount" required>
                         <button type="button" id="maxAmountButton" class="max-amount-button" title="Use maximum available balance" disabled>Max</button>
                     </div>
                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -45,7 +45,10 @@
         <div id="exchangeForm" class="exchange-form" style="display: none;">
             <form onsubmit="window.app.handleExchange(event)">
                 <div id="input" class="form-group">
-                    <input type="number" id="exchangeAmount" step="any" placeholder="Enter amount" required>
+                    <div class="amount-input-row">
+                        <input type="number" id="exchangeAmount" step="any" placeholder="Enter amount" required>
+                        <button type="button" id="maxAmountButton" class="max-amount-button" title="Use maximum available balance" disabled>Max</button>
+                    </div>
                 </div>
 
                 <!-- Optional: UBQ Discount (only shown when protocol allows) -->

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -35,6 +35,9 @@ button:disabled { cursor: not-allowed; }
 label {/* display: block; */margin: 8px;font-weight: 600;}
 input, select {padding: 10px;border: 1px solid #ddd;border-radius: 6px;font-size: 16px;background-color: transparent;border-color: transparent;box-shadow: 0 0 96px #ffffff40;color: #fff; }
 input:focus, select:focus { outline: none; }
+.amount-input-row {display: flex;gap: 8px;align-items: stretch;}
+.amount-input-row input {flex: 1;min-width: 0;}
+.max-amount-button {padding: 10px 14px;font-size: 14px;font-weight: 600;box-shadow: 0 0 48px #ffffff30;}
 .output-section { margin-top: 20px; padding: 20px; border-radius: 8px; }
 .output-row { display: flex; justify-content: space-between; margin-bottom: 10px; }
 .output-label { }

--- a/src/components/inventory-bar-component.ts
+++ b/src/components/inventory-bar-component.ts
@@ -8,6 +8,7 @@ import type { CentralizedRefreshService, RefreshData } from "../services/central
 import type { TokenBalance, InventoryBarState } from "../types/inventory.types.ts";
 import { formatTokenAmount, formatUsdValue, calculateTotalUsdValue, isBalanceZero } from "../utils/token-utils.ts";
 import { batchFetchTokenBalances } from "../utils/batch-request-utils.ts";
+import { getDisplayableBalances, MIN_DISPLAY_USD_VALUE } from "../utils/balance-utils.ts";
 
 import icons from "./icons.ts";
 
@@ -418,16 +419,16 @@ export class InventoryBarComponent {
       return;
     }
 
-    // Filter out zero balances and render individual token balances
-    const nonZeroBalances = this._state.balances.filter((balance) => !isBalanceZero(balance.balance, balance.decimals));
+    // Only show inventory balances with enough priced value to avoid noisy dust tokens.
+    const displayableBalances = getDisplayableBalances(this._state.balances);
 
-    if (nonZeroBalances.length === 0) {
-      tokensContainer.innerHTML = '<div class="no-balances-message">No token balances available</div>';
+    if (displayableBalances.length === 0) {
+      tokensContainer.innerHTML = `<div class="no-balances-message">No token balances over $${MIN_DISPLAY_USD_VALUE.toFixed(2)}</div>`;
       totalValueElement.textContent = "$0.00";
       return;
     }
 
-    const tokenElements = nonZeroBalances
+    const tokenElements = displayableBalances
       .map((balance) => {
         const amount = formatTokenAmount(balance.balance, balance.decimals);
         const usdValue = balance.usdValue ? formatUsdValue(balance.usdValue) : "";
@@ -447,7 +448,7 @@ export class InventoryBarComponent {
       .join("");
 
     tokensContainer.innerHTML = tokenElements;
-    totalValueElement.textContent = formatUsdValue(this._state.totalUsdValue);
+    totalValueElement.textContent = formatUsdValue(calculateTotalUsdValue(displayableBalances));
   }
 
   /**

--- a/src/components/simplified-exchange-component.ts
+++ b/src/components/simplified-exchange-component.ts
@@ -11,7 +11,7 @@ import { WALLET_EVENTS } from "../services/wallet-service.ts";
 import { LUSD_COLLATERAL } from "../contracts/constants.ts";
 import type { NotificationManager } from "./notification-manager.ts";
 import type { InventoryBarComponent } from "./inventory-bar-component.ts";
-import { getMaxTokenBalance, hasAvailableBalance } from "../utils/balance-utils.ts";
+import { getDisplayableBalances, getMaxTokenBalanceByAddress, hasAvailableBalanceByAddress } from "../utils/balance-utils.ts";
 import { DEFAULT_SLIPPAGE_PERCENT, DEFAULT_SLIPPAGE_BPS, BASIS_POINTS_DIVISOR } from "../constants/numeric-constants.ts";
 import type { CentralizedRefreshService, RefreshData } from "../services/centralized-refresh-service.ts";
 import { INVENTORY_TOKENS } from "../types/inventory.types.ts";
@@ -93,12 +93,6 @@ export class SimplifiedExchangeComponent {
 
     this._render();
 
-    // Auto-populate on initial load if wallet is connected
-    if (this._isWalletConnected()) {
-      // Balances are guaranteed to be loaded now
-      this._autoPopulateMaxBalance();
-    }
-
     // If we're starting on deposit mode, immediately hide UBQ option if minting disabled
     if (this._state.direction === "deposit" && this._state.mintingDisabled) {
       const ubqOptionDiv = document.getElementById("ubqDiscountOption");
@@ -162,74 +156,57 @@ export class SimplifiedExchangeComponent {
     }
     const yourTokenGroup = document.getElementById("yourTokenGroup") as HTMLOptGroupElement;
     const otherTokenGroup = document.getElementById("otherTokenGroup") as HTMLOptGroupElement;
+    const selectedValue = selectEl.value as Address | "";
 
-    if (refreshData?.tokenBalances) {
-      yourTokenGroup.style.display = "";
-      otherTokenGroup.style.display = "";
-      if (
-        refreshData.tokenBalances.some((balance) => areAddressesEqual(balance.address, INVENTORY_TOKENS.LUSD.address)) &&
-        !yourTokenGroup.querySelector(`option[value="${INVENTORY_TOKENS.LUSD.address}"i]`)
-      ) {
-        // Ensure LUSD is always in the first position
-        const option = document.createElement("option");
-        option.value = INVENTORY_TOKENS.LUSD.address;
-        option.setAttribute("data-decimals", INVENTORY_TOKENS.LUSD.decimals.toString());
-        option.setAttribute("data-symbol", INVENTORY_TOKENS.LUSD.symbol);
-        option.text = INVENTORY_TOKENS.LUSD.symbol.substring(0, 10);
-        yourTokenGroup.insertBefore(option, yourTokenGroup.firstChild);
-      }
-      refreshData.tokenBalances.forEach((balance) => {
-        if (yourTokenGroup.querySelector(`option[value="${balance.address}"i]`)) {
-          return; // Token already exists
-        }
-        otherTokenGroup.querySelector(`option[value="${balance.address}"i]`)?.remove(); // Remove from other tokens if present
+    yourTokenGroup.replaceChildren();
+    otherTokenGroup.replaceChildren();
 
-        const option = document.createElement("option");
-        option.value = balance.address;
-        option.setAttribute("data-decimals", balance.decimals.toString());
-        option.setAttribute("data-symbol", balance.symbol);
-        option.text = balance.symbol.substring(0, 10);
-        yourTokenGroup.appendChild(option);
+    const displayableBalances = getDisplayableBalances(refreshData?.tokenBalances ?? []);
+    const hasWalletTokens = displayableBalances.length > 0;
+
+    yourTokenGroup.style.display = hasWalletTokens ? "" : "none";
+    otherTokenGroup.style.display = hasWalletTokens ? "none" : "";
+
+    if (hasWalletTokens) {
+      const sortedBalances = [...displayableBalances].sort((a, b) => {
+        const isALusd = areAddressesEqual(a.address, INVENTORY_TOKENS.LUSD.address);
+        const isBLusd = areAddressesEqual(b.address, INVENTORY_TOKENS.LUSD.address);
+
+        if (isALusd && !isBLusd) return -1;
+        if (!isALusd && isBLusd) return 1;
+
+        return (b.usdValue ?? 0) - (a.usdValue ?? 0);
       });
-      // Remove old user's tokens
-      yourTokenGroup.querySelectorAll("option").forEach((opt) => {
-        if (!refreshData.tokenBalances?.some((balance) => areAddressesEqual(balance.address, opt.value as Address))) {
-          opt.remove();
-        }
+
+      sortedBalances.forEach((balance) => {
+        this._appendTokenOption(yourTokenGroup, balance);
       });
     } else {
-      yourTokenGroup.style.display = "none";
-      yourTokenGroup.querySelectorAll("option").forEach((opt) => opt.remove());
+      tokenList.forEach((token) => {
+        this._appendTokenOption(otherTokenGroup, {
+          address: token.address as Address,
+          decimals: token.decimals,
+          symbol: token.symbol,
+        });
+      });
     }
 
-    if (
-      !yourTokenGroup.querySelector(`option[value="${INVENTORY_TOKENS.LUSD.address}"i]`) &&
-      !otherTokenGroup.querySelector(`option[value="${INVENTORY_TOKENS.LUSD.address}"i]`)
-    ) {
-      // Ensure LUSD is always in the first position
-      const option = document.createElement("option");
-      option.value = INVENTORY_TOKENS.LUSD.address;
-      option.setAttribute("data-decimals", INVENTORY_TOKENS.LUSD.decimals.toString());
-      option.setAttribute("data-symbol", INVENTORY_TOKENS.LUSD.symbol);
-      option.text = INVENTORY_TOKENS.LUSD.symbol.substring(0, 10);
-      otherTokenGroup.insertBefore(option, otherTokenGroup.firstChild);
+    const hasSelectedOption = !!selectedValue && [...selectEl.options].some((option) => areAddressesEqual(option.value as Address, selectedValue as Address));
+
+    if (hasSelectedOption) {
+      selectEl.value = selectedValue;
+    } else if (selectEl.options.length > 0) {
+      selectEl.selectedIndex = 0;
     }
-    tokenList.forEach((token) => {
-      if ([...selectEl.options].some((opt) => areAddressesEqual(opt.value as Address, token.address as Address))) {
-        return; // Token already exists
-      }
-      const option = document.createElement("option");
-      option.value = token.address;
-      option.setAttribute("data-decimals", token.decimals.toString());
-      option.setAttribute("data-symbol", token.symbol);
-      option.text = token.symbol.substring(0, 10);
-      otherTokenGroup.appendChild(option);
-    });
-    otherTokenGroup.querySelectorAll("option").forEach((opt) => {
-      if (yourTokenGroup.querySelector(`option[value="${opt.value}"i]`)) {
-        opt.remove();
-      }
-    });
+  }
+
+  private _appendTokenOption(tokenGroup: HTMLOptGroupElement, token: { address: Address; decimals: number; symbol: string }) {
+    const option = document.createElement("option");
+    option.value = token.address;
+    option.setAttribute("data-decimals", token.decimals.toString());
+    option.setAttribute("data-symbol", token.symbol);
+    option.text = token.symbol.substring(0, 10);
+    tokenGroup.appendChild(option);
   }
 
   /**
@@ -298,7 +275,6 @@ export class SimplifiedExchangeComponent {
       await this._services.centralizedRefreshService.forceRefresh();
 
       this._render();
-      this._autoPopulateMaxBalance();
     });
 
     this._services.walletService.addEventListener(WALLET_EVENTS.DISCONNECT, async () => {
@@ -311,7 +287,7 @@ export class SimplifiedExchangeComponent {
       this._render();
     });
 
-    this._services.walletService.addEventListener(WALLET_EVENTS.ACCOUNT_CHANGED, async (account?: Address | null) => {
+    this._services.walletService.addEventListener(WALLET_EVENTS.ACCOUNT_CHANGED, async (_account?: Address | null) => {
       // Clear state and force re-evaluation when switching accounts
       this._state.amount = "";
       this._state.routeResult = null;
@@ -321,11 +297,6 @@ export class SimplifiedExchangeComponent {
       await this._services.centralizedRefreshService.forceRefresh();
       // Force a fresh render that will auto-select the correct direction
       this._render();
-
-      // If connected, auto-populate balance for the new account
-      if (account) {
-        this._autoPopulateMaxBalance();
-      }
     });
   }
 
@@ -337,6 +308,7 @@ export class SimplifiedExchangeComponent {
     // eslint-disable-next-line func-style
     const setupListeners = () => {
       const amountInput = document.getElementById("exchangeAmount") as HTMLInputElement;
+      const maxAmountButton = document.getElementById("maxAmountButton") as HTMLButtonElement;
       const depositButton = document.getElementById("depositButton") as HTMLButtonElement;
       const withdrawButton = document.getElementById("withdrawButton") as HTMLButtonElement;
       const ubqDiscountCheckbox = document.getElementById("useUbqDiscount") as HTMLInputElement;
@@ -344,13 +316,17 @@ export class SimplifiedExchangeComponent {
       const fractionalRedemptionCheckbox = document.getElementById("acceptFractionalRedemption") as HTMLInputElement;
 
       // Check if critical elements exist, if not retry
-      if (!amountInput || !depositButton || !withdrawButton) {
+      if (!amountInput || !maxAmountButton || !depositButton || !withdrawButton) {
         requestAnimationFrame(setupListeners);
         return;
       }
 
       if (amountInput) {
         amountInput.addEventListener("input", () => this._handleAmountChange());
+      }
+
+      if (maxAmountButton) {
+        maxAmountButton.addEventListener("click", () => this._handleMaxAmountClick());
       }
 
       if (depositButton) {
@@ -429,6 +405,58 @@ export class SimplifiedExchangeComponent {
     }, 1000);
   }
 
+  private _getMaxBalanceToken() {
+    return this._state.direction === "deposit" ? this._getSelectedToken() : INVENTORY_TOKENS.UUSD;
+  }
+
+  private _hasMaxAvailableBalance(): boolean {
+    try {
+      const token = this._getMaxBalanceToken();
+      return hasAvailableBalanceByAddress(this._services.inventoryBar, token.address);
+    } catch {
+      return false;
+    }
+  }
+
+  private _updateMaxButton() {
+    const maxAmountButton = document.getElementById("maxAmountButton") as HTMLButtonElement;
+    if (!maxAmountButton) {
+      return;
+    }
+
+    const isConnected = this._isWalletConnected();
+    const isBalancesLoading = isConnected && !this._services.inventoryBar.isInitialLoadComplete();
+    const hasMaxBalance = isConnected && !isBalancesLoading && this._hasMaxAvailableBalance();
+
+    maxAmountButton.disabled = !hasMaxBalance;
+    maxAmountButton.title = hasMaxBalance ? "Use maximum available balance" : "No available balance";
+  }
+
+  private _handleMaxAmountClick() {
+    if (!this._services.walletService.isConnected()) return;
+
+    const amountInput = document.getElementById("exchangeAmount") as HTMLInputElement;
+    if (!amountInput || amountInput.disabled) {
+      return;
+    }
+
+    try {
+      const token = this._getMaxBalanceToken();
+      const maxBalance = getMaxTokenBalanceByAddress(this._services.inventoryBar, token.address);
+
+      if (maxBalance === "0") {
+        return;
+      }
+
+      amountInput.value = maxBalance;
+      this._state.amount = maxBalance;
+      this._services.notificationManager.clearNotifications("exchange");
+      void this._calculateRoute();
+    } catch (error) {
+      console.error("Error setting max balance:", error);
+    }
+  }
+
   private _getSelectedToken() {
     const selectEl = document.getElementById("tokenSelect") as HTMLSelectElement;
     if (!selectEl) {
@@ -498,9 +526,6 @@ export class SimplifiedExchangeComponent {
 
     // Re-render UI
     this._render();
-
-    // Auto-populate with max balance if available
-    this._autoPopulateMaxBalance();
   }
 
   /**
@@ -638,6 +663,7 @@ export class SimplifiedExchangeComponent {
 
     // Show/hide options based on protocol state and direction
     this._renderTokenOptions();
+    this._updateMaxButton();
     this._renderOptions();
     this._renderOutput();
   }
@@ -1112,51 +1138,7 @@ export class SimplifiedExchangeComponent {
       this._services.inventoryBar.onBalancesUpdated(() => {
         // Re-render the UI to update button visibility based on new balances
         this._render();
-        this._autoPopulateMaxBalance();
       });
-    }
-  }
-
-  private _autoPopulateRetryTimeout: ReturnType<typeof setTimeout> | null = null;
-
-  /**
-   * Auto-populate with max balance
-   */
-  private _autoPopulateMaxBalance(retryCount: number = 0) {
-    // Cancel any pending retries when called
-    if (this._autoPopulateRetryTimeout) {
-      clearTimeout(this._autoPopulateRetryTimeout);
-      this._autoPopulateRetryTimeout = null;
-    }
-
-    if (!this._services.walletService.isConnected()) return;
-
-    const amountInput = document.getElementById("exchangeAmount") as HTMLInputElement;
-    if (!amountInput) {
-      // Retry if DOM element not ready (max 3 retries)
-      if (retryCount < 3) {
-        this._autoPopulateRetryTimeout = setTimeout(() => this._autoPopulateMaxBalance(retryCount + 1), 50);
-      }
-      return;
-    }
-
-    // Only auto-populate if input is empty or zero
-    if (amountInput.value && amountInput.value !== "" && amountInput.value !== "0") return;
-
-    try {
-      const selectedToken = this._state.direction === "deposit" ? this._getSelectedToken() : INVENTORY_TOKENS.UUSD;
-      const tokenSymbol = selectedToken.symbol;
-      if (hasAvailableBalance(this._services.inventoryBar, tokenSymbol)) {
-        const maxBalance = getMaxTokenBalance(this._services.inventoryBar, tokenSymbol);
-        amountInput.value = maxBalance;
-        this._state.amount = maxBalance;
-        void this._calculateRoute();
-      } else if (retryCount < 3 && !this._services.inventoryBar.isInitialLoadComplete()) {
-        // If balances not loaded yet, retry
-        this._autoPopulateRetryTimeout = setTimeout(() => this._autoPopulateMaxBalance(retryCount + 1), 100);
-      }
-    } catch (error) {
-      console.error("Error auto-populating max balance:", error);
     }
   }
 

--- a/src/components/simplified-exchange-component.ts
+++ b/src/components/simplified-exchange-component.ts
@@ -197,6 +197,16 @@ export class SimplifiedExchangeComponent {
       selectEl.value = selectedValue;
     } else if (selectEl.options.length > 0) {
       selectEl.selectedIndex = 0;
+
+      if (selectedValue) {
+        const amountInput = document.getElementById("exchangeAmount") as HTMLInputElement | null;
+        if (amountInput) {
+          amountInput.value = "";
+        }
+        this._state.amount = "";
+        this._state.routeResult = null;
+        this._services.notificationManager.clearNotifications("exchange");
+      }
     }
   }
 

--- a/src/utils/balance-utils.ts
+++ b/src/utils/balance-utils.ts
@@ -1,10 +1,18 @@
-import { formatUnits } from "viem";
-import type { TokenBalance as _TokenBalance } from "../types/inventory.types.ts";
+import { formatUnits, type Address } from "viem";
+import type { TokenBalance } from "../types/inventory.types.ts";
 import type { InventoryBarComponent } from "../components/inventory-bar-component.ts";
+import { areAddressesEqual } from "./format-utils.ts";
+
+export const MIN_DISPLAY_USD_VALUE = 1;
 
 /**
- * Balance utilities for auto-population of input fields
+ * Balance utilities for inventory display and amount input fields
  */
+
+function formatBalanceForInput(tokenBalance: TokenBalance): string {
+  const formattedBalance = formatUnits(tokenBalance.balance, tokenBalance.decimals);
+  return formattedBalance.replace(/\.?0+$/, "") || "0";
+}
 
 /**
  * Get the maximum available balance for a specific token from inventory bar
@@ -21,13 +29,25 @@ export function getMaxTokenBalance(inventoryBar: InventoryBarComponent, tokenSym
     return "0";
   }
 
-  // Convert to human-readable format for input field
-  const formattedBalance = formatUnits(tokenBalance.balance, tokenBalance.decimals);
+  return formatBalanceForInput(tokenBalance);
+}
 
-  // Remove trailing zeros and ensure clean formatting
-  const cleanBalance = formattedBalance.replace(/\.?0+$/, "");
+/**
+ * Get the maximum available balance for a specific token address from inventory bar
+ */
+export function getMaxTokenBalanceByAddress(inventoryBar: InventoryBarComponent, tokenAddress: Address): string {
+  if (!inventoryBar) {
+    return "0";
+  }
 
-  return cleanBalance;
+  const balances = inventoryBar.getBalances();
+  const tokenBalance = balances.find((balance) => areAddressesEqual(balance.address, tokenAddress));
+
+  if (!tokenBalance) {
+    return "0";
+  }
+
+  return formatBalanceForInput(tokenBalance);
 }
 
 /**
@@ -42,6 +62,34 @@ export function hasAvailableBalance(inventoryBar: InventoryBarComponent, tokenSy
   }
 
   return tokenBalance.balance > 0n;
+}
+
+/**
+ * Check if a token balance is available for a specific token address
+ */
+export function hasAvailableBalanceByAddress(inventoryBar: InventoryBarComponent, tokenAddress: Address): boolean {
+  const balances = inventoryBar.getBalances();
+  const tokenBalance = balances.find((balance) => areAddressesEqual(balance.address, tokenAddress));
+
+  if (!tokenBalance) {
+    return false;
+  }
+
+  return tokenBalance.balance > 0n;
+}
+
+/**
+ * Check whether a token balance is large enough to display in inventory UI
+ */
+export function hasDisplayableUsdValue(tokenBalance: TokenBalance): boolean {
+  return tokenBalance.balance > 0n && (tokenBalance.usdValue ?? 0) > MIN_DISPLAY_USD_VALUE;
+}
+
+/**
+ * Filter wallet balances to the minimum USD value shown in inventory-facing UI
+ */
+export function getDisplayableBalances(balances: TokenBalance[]): TokenBalance[] {
+  return balances.filter(hasDisplayableUsdValue);
 }
 
 /**

--- a/src/utils/balance-utils.ts
+++ b/src/utils/balance-utils.ts
@@ -11,7 +11,11 @@ export const MIN_DISPLAY_USD_VALUE = 1;
 
 function formatBalanceForInput(tokenBalance: TokenBalance): string {
   const formattedBalance = formatUnits(tokenBalance.balance, tokenBalance.decimals);
-  return formattedBalance.replace(/\.?0+$/, "") || "0";
+  if (!formattedBalance.includes(".")) {
+    return formattedBalance;
+  }
+
+  return formattedBalance.replace(/(\.\d*?[1-9])0+$/, "$1").replace(/\.0+$/, "") || "0";
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes the remaining CoWSwap integration UX items from issue #47 and includes the CodeRabbit review fixes from the closed PR #82.

Resolves #47

## Changes
- Filters inventory display/token selection to balances with displayable value.
- Adds an explicit Max amount button for the selected token.
- Adds an accessible name to the exchange amount input.
- Clears stale amount/route state when the selected token is replaced after inventory filtering.
- Preserves significant integer trailing zeros when formatting max balances, so values like `1000` do not become `1`.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npx --yes deno task build`

## Notes
This supersedes closed PR #82/#83. PR #82 received three CodeRabbit actionable comments; all three are addressed here.